### PR TITLE
fix: データ収集スクリプトの改善とデバッグツールの追加

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ numpy==1.26.4
 openpyxl==3.1.2
 
 # 機械学習
-scikit-learn==1.3.2
+scikit-learn==1.5.0
 lightgbm==4.1.0
 xgboost==2.0.2
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,37 +1,55 @@
-# 大井競馬予想AI用環境设置
-# 以下のコマンドでインストール: pip install -r requirements.txt
+# 大井競馬予想AI 依存関係
+# Python 3.13対応版
 
-# スクレイピング用
+# Web スクレイピング
 requests==2.31.0
 beautifulsoup4==4.12.2
-lxml==4.9.3
+lxml==5.2.2
 selenium==4.15.0
 
-# データ処理用
-pandas==2.1.3
-numpy==1.24.3
+# データ処理
+pandas==2.2.2
+numpy==1.26.4
 openpyxl==3.1.2
 
-# 機械学習用
-lightgbm==4.1.0
+# 機械学習
 scikit-learn==1.3.2
+lightgbm==4.1.0
 xgboost==2.0.2
 
-# データベース用
+# データベース
 sqlalchemy==2.0.23
+# sqlite3は標準ライブラリに含まれる
 
-# 日時処理用
-python-dateutil==2.8.2
+# ログ
+loguru==0.7.2
 
-# 可視化用
+# 環境変数
+python-dotenv==1.0.0
+
+# Webアプリ
+streamlit==1.29.0
+
+# データ可視化
 matplotlib==3.8.2
 seaborn==0.13.0
+plotly==5.18.0
 
-# 進捗表示用
+# 日時処理
+python-dateutil==2.8.2
+
+# 進捗表示
 tqdm==4.66.1
 
-# HTTP処理用
+# HTTP処理
 urllib3==2.1.0
 
-# JRA-VAN用（後で追加設定が必要）
-# JRA-VAN SDK for Python（別途インストール）
+# その他ユーティリティ
+joblib==1.3.2
+
+# 開発ツール
+pytest==7.4.3
+black==23.11.0
+flake8==6.1.0
+ipython==8.18.1
+jupyter==1.0.0

--- a/scripts/create_sample_data_v2.py
+++ b/scripts/create_sample_data_v2.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""
+大井競馬AIシステムのテスト用サンプルデータを作成するスクリプト
+実際のデータ形式に近い形でサンプルを生成し、システム全体の動作確認を可能にする
+"""
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import random
+from datetime import datetime, timedelta
+import pandas as pd
+import sqlite3
+from pathlib import Path
+
+from config.settings import DATABASE_PATH
+from src.data_collection.database import OiKeibaDatabase
+from src.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+class SampleDataGenerator:
+    def __init__(self):
+        self.db = OiKeibaDatabase()
+        
+        # サンプル用の馬名
+        self.horse_names = [
+            "シンボリクリスエス", "ディープインパクト", "オルフェーヴル", "ジェンティルドンナ",
+            "ゴールドシップ", "キタサンブラック", "アーモンドアイ", "コントレイル",
+            "デアリングタクト", "エフフォーリア", "イクイノックス", "ドウデュース",
+            "リバティアイランド", "ウシュバテソーロ", "タイトルホルダー", "パンサラッサ"
+        ]
+        
+        # サンプル用の騎手名
+        self.jockey_names = [
+            "武豊", "福永祐一", "川田将雅", "ルメール", "デムーロ", "戸崎圭太",
+            "田辺裕信", "横山典弘", "池添謙一", "松山弘平", "藤岡佑介", "岩田望来"
+        ]
+        
+        # サンプル用の調教師名
+        self.trainer_names = [
+            "藤沢和雄", "堀宣行", "友道康夫", "国枝栄", "矢作芳人", "木村哲也",
+            "中内田充正", "高野友和", "斉藤崇史", "杉山晴紀"
+        ]
+        
+        # レース名のテンプレート
+        self.race_name_templates = [
+            "東京大賞典", "帝王賞", "マイルチャンピオンシップ南部杯", "かしわ記念",
+            "大井記念", "東京シティカップ", "優駿スプリント", "サンタアニタトロフィー",
+            "3歳特別", "C1特別", "B2特別", "未勝利戦"
+        ]
+    
+    def generate_race_data(self, num_days=30, races_per_day=8):
+        """レースデータを生成"""
+        logger.info(f"{num_days}日分のレースデータを生成開始...")
+        
+        race_results = []
+        end_date = datetime.now()
+        
+        for day_offset in range(num_days):
+            race_date = end_date - timedelta(days=day_offset)
+            
+            # 土日水曜日のみ開催
+            if race_date.weekday() not in [2, 5, 6]:  # 水、土、日
+                continue
+            
+            for race_num in range(1, races_per_day + 1):
+                race_id = f"S{race_date.strftime('%Y%m%d')}{race_num:02d}"
+                race_name = f"{random.choice(self.race_name_templates)} (R{race_num})"
+                
+                # レース条件
+                course_length = random.choice([1200, 1400, 1600, 1800, 2000])
+                course_type = "ダート"  # 大井は基本ダート
+                weather = random.choice(["晴", "曇", "雨", "小雨"])
+                track_condition = random.choice(["良", "稍重", "重", "不良"])
+                
+                # 出走頭数
+                num_horses = random.randint(8, 16)
+                
+                # 各馬の結果を生成
+                horses = random.sample(self.horse_names, min(num_horses, len(self.horse_names)))
+                jockeys = [random.choice(self.jockey_names) for _ in range(num_horses)]
+                trainers = [random.choice(self.trainer_names) for _ in range(num_horses)]
+                
+                # オッズと人気順を生成
+                odds_list = sorted([random.uniform(1.5, 100.0) for _ in range(num_horses)])
+                
+                for position in range(1, num_horses + 1):
+                    # ランダムに馬を選んで着順を決定
+                    horse_idx = position - 1
+                    
+                    result = {
+                        'race_id': race_id,
+                        'race_date': race_date.strftime('%Y-%m-%d'),
+                        'race_name': race_name,
+                        'course_length': course_length,
+                        'course_type': course_type,
+                        'weather': weather,
+                        'track_condition': track_condition,
+                        'finish_position': position,
+                        'horse_name': horses[horse_idx],
+                        'jockey_name': jockeys[horse_idx],
+                        'trainer_name': trainers[horse_idx],
+                        'horse_weight': random.randint(440, 520),
+                        'odds': odds_list[horse_idx],
+                        'popularity': horse_idx + 1,
+                        'time_result': f"{course_length//1000}:{random.randint(10,59)}.{random.randint(0,9)}",
+                        'margin': "アタマ" if position == 1 else random.choice(["アタマ", "クビ", "1/2馬身", "1馬身", "2馬身"])
+                    }
+                    race_results.append(result)
+        
+        logger.info(f"生成されたレース結果: {len(race_results)}件")
+        return race_results
+    
+    def generate_horse_data(self, race_results):
+        """馬の基本情報を生成"""
+        logger.info("馬の基本情報を生成中...")
+        
+        horses_df = pd.DataFrame(race_results)
+        unique_horses = horses_df['horse_name'].unique()
+        
+        horses_data = []
+        for horse_name in unique_horses:
+            horse_data = {
+                'horse_name': horse_name,
+                'birth_year': random.randint(2018, 2022),
+                'sex': random.choice(['牡', '牝', 'セ']),
+                'father': random.choice(["ディープインパクト", "ロードカナロア", "キングカメハメハ", "ハーツクライ"]),
+                'mother': f"母馬{random.randint(1, 100)}",
+                'trainer_name': random.choice(self.trainer_names),
+                'owner_name': f"オーナー{random.randint(1, 50)}",
+                'breeder_name': f"生産者{random.randint(1, 30)}"
+            }
+            horses_data.append(horse_data)
+        
+        return horses_data
+    
+    def generate_jra_horse_records(self, horses_data):
+        """JRA転入馬の記録を生成"""
+        logger.info("JRA転入馬データを生成中...")
+        
+        jra_records = []
+        # 一部の馬をJRA転入馬として設定
+        jra_horses = random.sample(horses_data, k=len(horses_data)//3)
+        
+        for horse in jra_horses:
+            # JRAでの戦績を生成
+            num_races = random.randint(5, 20)
+            wins = random.randint(0, min(3, num_races//3))
+            seconds = random.randint(0, min(3, (num_races-wins)//2))
+            thirds = random.randint(0, min(3, num_races-wins-seconds))
+            
+            record = {
+                'horse_name': horse['horse_name'],
+                'jra_races': num_races,
+                'jra_wins': wins,
+                'jra_seconds': seconds,
+                'jra_thirds': thirds,
+                'jra_earnings': random.randint(1000000, 50000000),
+                'jra_last_race_date': (datetime.now() - timedelta(days=random.randint(30, 180))).strftime('%Y-%m-%d'),
+                'jra_last_race_name': random.choice(["東京記念", "中山大障害", "阪神カップ", "新馬戦"]),
+                'jra_last_position': random.randint(1, 10)
+            }
+            jra_records.append(record)
+        
+        return jra_records
+    
+    def generate_jockey_trainer_stats(self, race_results):
+        """騎手・調教師の統計を生成"""
+        logger.info("騎手・調教師統計を生成中...")
+        
+        stats = []
+        
+        # 騎手統計
+        results_df = pd.DataFrame(race_results)
+        for jockey in self.jockey_names:
+            jockey_races = results_df[results_df['jockey_name'] == jockey]
+            if len(jockey_races) > 0:
+                wins = len(jockey_races[jockey_races['finish_position'] == 1])
+                stat = {
+                    'person_type': 'jockey',
+                    'person_name': jockey,
+                    'year': 2025,
+                    'total_races': len(jockey_races),
+                    'wins': wins,
+                    'win_rate': wins / len(jockey_races) if len(jockey_races) > 0 else 0,
+                    'top3_rate': len(jockey_races[jockey_races['finish_position'] <= 3]) / len(jockey_races) if len(jockey_races) > 0 else 0
+                }
+                stats.append(stat)
+        
+        # 調教師統計
+        for trainer in self.trainer_names:
+            trainer_races = results_df[results_df['trainer_name'] == trainer]
+            if len(trainer_races) > 0:
+                wins = len(trainer_races[trainer_races['finish_position'] == 1])
+                stat = {
+                    'person_type': 'trainer',
+                    'person_name': trainer,
+                    'year': 2025,
+                    'total_races': len(trainer_races),
+                    'wins': wins,
+                    'win_rate': wins / len(trainer_races) if len(trainer_races) > 0 else 0,
+                    'top3_rate': len(trainer_races[trainer_races['finish_position'] <= 3]) / len(trainer_races) if len(trainer_races) > 0 else 0
+                }
+                stats.append(stat)
+        
+        return stats
+    
+    def save_to_database(self, race_results, horses_data, jra_records, stats):
+        """データベースに保存"""
+        logger.info("データベースに保存中...")
+        
+        # レース結果を保存
+        self.db.save_race_results(race_results)
+        
+        # 馬データを保存
+        conn = sqlite3.connect(DATABASE_PATH)
+        
+        # horsesテーブル
+        horses_df = pd.DataFrame(horses_data)
+        horses_df.to_sql('horses', conn, if_exists='replace', index=False)
+        
+        # jra_horse_recordsテーブル
+        jra_df = pd.DataFrame(jra_records)
+        jra_df.to_sql('jra_horse_records', conn, if_exists='replace', index=False)
+        
+        # jockey_trainer_statsテーブル
+        stats_df = pd.DataFrame(stats)
+        stats_df.to_sql('jockey_trainer_stats', conn, if_exists='replace', index=False)
+        
+        conn.close()
+        
+        logger.info("データベースへの保存完了！")
+    
+    def verify_data(self):
+        """保存されたデータを確認"""
+        logger.info("\nデータベースの内容を確認中...")
+        
+        conn = sqlite3.connect(DATABASE_PATH)
+        
+        # 各テーブルのレコード数を確認
+        tables = ['race_results', 'horses', 'jra_horse_records', 'jockey_trainer_stats']
+        
+        for table in tables:
+            count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+            logger.info(f"{table}: {count}件")
+            
+            # サンプルデータを表示
+            df = pd.read_sql_query(f"SELECT * FROM {table} LIMIT 3", conn)
+            print(f"\n{table}のサンプル:")
+            print(df)
+        
+        conn.close()
+
+def main():
+    """メイン処理"""
+    logger.info("サンプルデータ生成を開始します...")
+    
+    generator = SampleDataGenerator()
+    
+    # データ生成
+    race_results = generator.generate_race_data(num_days=60, races_per_day=10)
+    horses_data = generator.generate_horse_data(race_results)
+    jra_records = generator.generate_jra_horse_records(horses_data)
+    stats = generator.generate_jockey_trainer_stats(race_results)
+    
+    # データベースに保存
+    generator.save_to_database(race_results, horses_data, jra_records, stats)
+    
+    # データ確認
+    generator.verify_data()
+    
+    logger.info("\nサンプルデータの生成が完了しました！")
+    logger.info("以下のコマンドでシステムをテストできます:")
+    logger.info("1. モデル訓練: python scripts/train_model.py")
+    logger.info("2. 予想実行: python scripts/daily_prediction.py --dry-run")
+    logger.info("3. Webアプリ: streamlit run web_app/app.py")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/debug_netkeiba_url.py
+++ b/scripts/debug_netkeiba_url.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""
+netkeibaのURL形式とコースコードを調査するスクリプト
+"""
+import requests
+from bs4 import BeautifulSoup
+import time
+from datetime import datetime, timedelta
+
+def test_netkeiba_urls():
+    """様々なURL形式を試して、正しい形式を見つける"""
+    
+    # User-Agentを設定
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+    }
+    
+    # テストする日付（最近の日付）
+    test_date = datetime(2025, 6, 25)
+    date_str = test_date.strftime('%Y%m%d')
+    
+    # 試すべきURL形式のリスト
+    url_patterns = [
+        # 現在の形式
+        f"https://db.netkeiba.com/race/list/30{date_str}/",
+        
+        # 他の可能性のある形式
+        f"https://race.netkeiba.com/race/shutuba_past.html?kaisai_date={date_str}&jyo_cd=30",
+        f"https://race.netkeiba.com/top/race_list_sub.html?kaisai_date={date_str}&jyo_cd=30",
+        f"https://race.netkeiba.com/top/calendar.html?year={test_date.year}&month={test_date.month}",
+        
+        # 大井競馬場の他の可能なコード
+        f"https://db.netkeiba.com/race/list/03{date_str}/",  # 03
+        f"https://db.netkeiba.com/race/list/44{date_str}/",  # 44
+        
+        # 地方競馬用の形式
+        f"https://nar.netkeiba.com/race/list/{date_str}/",
+        f"https://nar.netkeiba.com/calendar/top/{test_date.strftime('%Y-%m')}/",
+    ]
+    
+    print(f"テスト日付: {test_date.strftime('%Y-%m-%d')}")
+    print("=" * 60)
+    
+    for url in url_patterns:
+        print(f"\n試行中: {url}")
+        
+        try:
+            response = requests.get(url, headers=headers, timeout=10)
+            print(f"ステータスコード: {response.status_code}")
+            
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.content, 'html.parser')
+                
+                # ページタイトルを確認
+                title = soup.find('title')
+                if title:
+                    print(f"ページタイトル: {title.text.strip()}")
+                
+                # 大井関連のキーワードを探す
+                page_text = soup.text.lower()
+                if '大井' in page_text or 'oi' in page_text or '東京シティ' in page_text:
+                    print("✅ 大井競馬関連のコンテンツが見つかりました！")
+                    
+                    # レースリンクを探す
+                    race_links = soup.find_all('a', href=lambda x: x and '/race/' in x and len(x.split('/')) > 2)
+                    print(f"レースリンク数: {len(race_links)}")
+                    
+                    if race_links:
+                        print("サンプルレースリンク:")
+                        for link in race_links[:3]:  # 最初の3つを表示
+                            print(f"  - {link.get('href')}")
+                else:
+                    print("❌ 大井競馬関連のコンテンツが見つかりません")
+                    
+            elif response.status_code == 404:
+                print("❌ ページが見つかりません (404)")
+            else:
+                print(f"❌ エラー: {response.status_code}")
+                
+        except requests.RequestException as e:
+            print(f"❌ リクエストエラー: {e}")
+        
+        time.sleep(1)  # サーバーに負荷をかけないように
+    
+    print("\n" + "=" * 60)
+    print("地方競馬公式サイトの確認")
+    print("=" * 60)
+    
+    # 地方競馬情報サイトも確認
+    nar_urls = [
+        "https://www.keiba.go.jp/KeibaWeb/TodayRaceInfo/RaceList",  # 地方競馬公式
+        "https://www.tokyocitykeiba.com/",  # 東京シティ競馬（大井）
+    ]
+    
+    for url in nar_urls:
+        print(f"\n確認中: {url}")
+        try:
+            response = requests.get(url, headers=headers, timeout=10)
+            print(f"ステータスコード: {response.status_code}")
+            if response.status_code == 200:
+                print("✅ アクセス可能")
+        except:
+            print("❌ アクセスエラー")
+        time.sleep(1)
+
+def check_specific_race():
+    """特定のレースページを直接確認"""
+    print("\n" + "=" * 60)
+    print("特定レースページの確認")
+    print("=" * 60)
+    
+    headers = {
+        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+    }
+    
+    # 大井競馬の最近のレースIDを推測
+    # 通常、レースIDは YYYYMMDDHHTT 形式（HH:開催回次、TT:競走番号）
+    test_ids = [
+        "202503440101",  # 2025年03月44回01レース
+        "202544030101",  # 2025年44回03回01レース
+        "c202544030101", # 地方競馬用プレフィックス付き
+    ]
+    
+    for race_id in test_ids:
+        url = f"https://db.netkeiba.com/race/{race_id}/"
+        print(f"\n試行中: {url}")
+        
+        try:
+            response = requests.get(url, headers=headers, timeout=10)
+            print(f"ステータスコード: {response.status_code}")
+            
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.content, 'html.parser')
+                title = soup.find('h1')
+                if title and ('大井' in title.text or '東京シティ' in title.text):
+                    print(f"✅ 大井競馬のレースが見つかりました: {title.text}")
+                
+        except requests.RequestException as e:
+            print(f"❌ エラー: {e}")
+        
+        time.sleep(1)
+
+if __name__ == "__main__":
+    print("netkeibaのURL形式調査を開始します...")
+    print("=" * 60)
+    
+    # URL形式のテスト
+    test_netkeiba_urls()
+    
+    # 特定レースの確認
+    check_specific_race()
+    
+    print("\n調査完了！")
+    print("\n【推奨事項】")
+    print("1. 正しいURL形式が見つかったら、settings.pyを更新してください")
+    print("2. 地方競馬（NAR）用の専用URLを使う必要があるかもしれません")
+    print("3. 東京シティ競馬公式サイトも代替データソースとして検討してください")

--- a/scripts/run_data_collection.py
+++ b/scripts/run_data_collection.py
@@ -1,29 +1,178 @@
 #!/usr/bin/env python3
 """
 データ収集実行スクリプト
+コマンドライン引数で期間を指定可能
 """
 import sys
+import argparse
 from pathlib import Path
+from datetime import datetime, timedelta
 
 # プロジェクトルートを追加
 sys.path.append(str(Path(__file__).parent.parent))
 
 from src.data_collection.scraper import OiKeibaScraper
+from src.data_collection.database import OiKeibaDatabase
 from src.utils.logger import setup_logger
 
+
+def parse_date(date_str):
+    """日付文字列をパース"""
+    try:
+        return datetime.strptime(date_str, '%Y-%m-%d')
+    except ValueError:
+        raise argparse.ArgumentTypeError(f"日付は YYYY-MM-DD 形式で指定してください: {date_str}")
+
+
 def main():
-    logger = setup_logger(__name__, 'data_collection.log')
-    logger.info("データ収集を開始します")
+    # コマンドライン引数の設定
+    parser = argparse.ArgumentParser(
+        description='大井競馬のレースデータを収集します',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+使用例:
+  # 過去3ヶ月のデータを収集
+  python scripts/run_data_collection.py --months-back 3
+  
+  # 特定期間のデータを収集
+  python scripts/run_data_collection.py --start-date 2025-06-01 --end-date 2025-06-25
+  
+  # 最近7日間のデータを収集
+  python scripts/run_data_collection.py --days-back 7
+        """
+    )
+    
+    # 期間指定オプション（3つの方法から選択）
+    period_group = parser.add_mutually_exclusive_group()
+    period_group.add_argument(
+        '--months-back',
+        type=int,
+        help='何ヶ月前からのデータを収集するか（デフォルト: 36）'
+    )
+    period_group.add_argument(
+        '--days-back',
+        type=int,
+        help='何日前からのデータを収集するか'
+    )
+    period_group.add_argument(
+        '--start-date',
+        type=parse_date,
+        help='収集開始日（YYYY-MM-DD形式）'
+    )
+    
+    # 終了日オプション（start-dateと組み合わせて使用）
+    parser.add_argument(
+        '--end-date',
+        type=parse_date,
+        help='収集終了日（YYYY-MM-DD形式、デフォルト: 今日）'
+    )
+    
+    # その他のオプション
+    parser.add_argument(
+        '--dry-run',
+        action='store_true',
+        help='実際にはデータを保存せず、収集対象を確認するだけ'
+    )
+    parser.add_argument(
+        '--verbose',
+        '-v',
+        action='store_true',
+        help='詳細なログを出力'
+    )
+    
+    args = parser.parse_args()
+    
+    # ロガーの設定
+    log_level = 'DEBUG' if args.verbose else 'INFO'
+    logger = setup_logger(__name__, 'data_collection.log', level=log_level)
+    
+    # 期間の決定
+    end_date = args.end_date or datetime.now()
+    
+    if args.start_date:
+        if args.end_date and args.start_date > args.end_date:
+            logger.error("開始日が終了日より後になっています")
+            return 1
+        start_date = args.start_date
+        logger.info(f"指定期間: {start_date.strftime('%Y-%m-%d')} から {end_date.strftime('%Y-%m-%d')}")
+        
+    elif args.days_back:
+        start_date = end_date - timedelta(days=args.days_back)
+        logger.info(f"過去 {args.days_back} 日間のデータを収集")
+        
+    elif args.months_back:
+        start_date = end_date - timedelta(days=args.months_back * 30)
+        logger.info(f"過去 {args.months_back} ヶ月間のデータを収集")
+        
+    else:
+        # デフォルトは36ヶ月
+        months_back = 36
+        start_date = end_date - timedelta(days=months_back * 30)
+        logger.info(f"デフォルト設定: 過去 {months_back} ヶ月間のデータを収集")
+    
+    # 収集期間の確認
+    total_days = (end_date - start_date).days
+    logger.info(f"収集期間: {start_date.strftime('%Y-%m-%d')} 〜 {end_date.strftime('%Y-%m-%d')} ({total_days}日間)")
+    
+    if args.dry_run:
+        logger.info("ドライランモード: データの保存は行いません")
     
     try:
-        scraper = OiKeibaScraper()
-        scraper.run_scraping(months_back=36)
-        logger.info("データ収集が完了しました")
+        # スクレイパーの初期化
+        db = OiKeibaDatabase() if not args.dry_run else None
+        scraper = OiKeibaScraper(db=db)
+        
+        # データ収集の実行
+        logger.info("データ収集を開始します...")
+        
+        # get_race_listメソッドを直接呼び出し
+        race_list = scraper.get_race_list(start_date, end_date)
+        logger.info(f"取得対象レース数: {len(race_list)}")
+        
+        if args.dry_run:
+            # ドライランモードでは最初の10件を表示
+            logger.info("ドライランモード: 収集対象レースの確認")
+            for i, race in enumerate(race_list[:10]):
+                logger.info(f"  {i+1}. {race['race_date']} - {race['race_name']} (ID: {race['race_id']})")
+            if len(race_list) > 10:
+                logger.info(f"  ... 他 {len(race_list) - 10} レース")
+        else:
+            # 実際のデータ収集
+            import time
+            from config.settings import SCRAPING_DELAY
+            
+            for i, race in enumerate(race_list):
+                logger.info(f"進捗: {i+1}/{len(race_list)} - {race['race_name']}")
+                
+                results = scraper.scrape_race_result(race['race_id'], race['race_date'])
+                if results:
+                    scraper.db.save_race_results(results)
+                    logger.info(f"保存完了: {len(results)}件")
+                else:
+                    logger.warning(f"データ取得失敗: {race['race_id']}")
+                
+                # サーバーに負荷をかけないように待機
+                if i < len(race_list) - 1:  # 最後のレースの後は待機不要
+                    time.sleep(SCRAPING_DELAY)
+        
+        logger.info("データ収集が完了しました！")
+        
+        # 統計情報の表示
+        if not args.dry_run and scraper.db:
+            conn = scraper.db.get_connection()
+            total_records = conn.execute("SELECT COUNT(*) FROM race_results").fetchone()[0]
+            logger.info(f"データベース内の総レコード数: {total_records}")
+            conn.close()
+        
+        return 0
+        
     except Exception as e:
         logger.error(f"データ収集エラー: {e}")
+        if args.verbose:
+            import traceback
+            logger.error(traceback.format_exc())
         return 1
-    
-    return 0
+
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
## 🔧 修正内容

### Issue #3: データ収集スクリプトの日付オプション対応
- `scripts/run_data_collection.py` にコマンドライン引数を追加
- `--start-date`, `--end-date`, `--days-back`, `--months-back` オプションを実装
- `--dry-run` モードと `--verbose` オプションも追加

### 追加ツール
1. **netkeibaのURL調査スクリプト** (`scripts/debug_netkeiba_url.py`)
   - 様々なURL形式を試して正しい形式を見つけるデバッグツール
   - 大井競馬場の正しいコースコードを特定するため

2. **改良版サンプルデータ作成スクリプト** (`scripts/create_sample_data_v2.py`)
   - システム全体の動作確認用の現実的なサンプルデータを生成
   - 実際のデータ形式に準拠した構造

## 📋 テスト方法

### 1. データ収集スクリプトのテスト
```bash
# 日付指定でデータ収集（ドライラン）
python scripts/run_data_collection.py --start-date 2025-06-01 --end-date 2025-06-25 --dry-run

# 最近7日間のデータ収集
python scripts/run_data_collection.py --days-back 7 --verbose
```

### 2. サンプルデータでの動作確認
```bash
# サンプルデータ作成
python scripts/create_sample_data_v2.py

# モデル訓練
python scripts/train_model.py

# 予想実行
python scripts/daily_prediction.py --dry-run
```

## 🎯 今後の課題
- Issue #4: netkeibaからのデータ取得問題は、URL調査スクリプトの結果を基に別途対応予定