### PR TITLE
feat: 東京シティ競馬スクレイピング調査とプロトタイプ実装

### DIFF
--- a/scripts/investigate_nankan_keiba.py
+++ b/scripts/investigate_nankan_keiba.py
@@ -1,0 +1,303 @@
+#!/usr/bin/env python3
+"""
+南関競馬サイトのレース結果ページを調査するスクリプト
+大井競馬のデータ構造を解析する
+"""
+import requests
+from bs4 import BeautifulSoup
+import time
+from datetime import datetime
+import re
+from urllib.parse import urljoin
+
+class NankanKeibaInvestigator:
+    def __init__(self):
+        self.base_url = "http://www.nankankeiba.com/"
+        self.headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        }
+        self.session = requests.Session()
+        self.session.headers.update(self.headers)
+        
+        # 東京シティ競馬から発見したレース結果URL
+        self.sample_result_urls = [
+            "http://www.nankankeiba.com/result/2025012920160311.do",
+            "http://www.nankankeiba.com/result/2025021920170311.do",
+            "http://www.nankankeiba.com/result/2025031320180411.do",
+            "http://www.nankankeiba.com/result/2025032620190311.do",
+            "http://www.nankankeiba.com/result/2025041620010311.do"
+        ]
+    
+    def check_robots_txt(self):
+        """robots.txtを確認"""
+        print("=" * 60)
+        print("robots.txtの確認")
+        print("=" * 60)
+        
+        try:
+            url = urljoin(self.base_url, "robots.txt")
+            response = self.session.get(url, timeout=10)
+            
+            if response.status_code == 200:
+                print("✅ robots.txt が見つかりました:")
+                print(response.text[:500])  # 最初の500文字
+            else:
+                print(f"❌ robots.txt が見つかりません (ステータス: {response.status_code})")
+        except Exception as e:
+            print(f"❌ エラー: {e}")
+    
+    def analyze_url_pattern(self):
+        """URLパターンを分析"""
+        print("\n" + "=" * 60)
+        print("URLパターンの分析")
+        print("=" * 60)
+        
+        for url in self.sample_result_urls:
+            # URLからパラメータを抽出
+            match = re.search(r'/result/(\d{8})(\d+)\.do', url)
+            if match:
+                date_part = match.group(1)
+                code_part = match.group(2)
+                
+                # 日付を解析
+                date_obj = datetime.strptime(date_part, '%Y%m%d')
+                
+                print(f"\nURL: {url}")
+                print(f"  日付: {date_obj.strftime('%Y年%m月%d日')}")
+                print(f"  コード部分: {code_part}")
+                
+                # コード部分を分析
+                if len(code_part) >= 8:
+                    possible_track = code_part[:2]
+                    possible_kaisai = code_part[2:4]
+                    possible_day = code_part[4:6]
+                    possible_race = code_part[6:8]
+                    
+                    print(f"  可能な構造:")
+                    print(f"    - 競馬場コード: {possible_track}")
+                    print(f"    - 開催回次: {possible_kaisai}")
+                    print(f"    - 日次: {possible_day}")
+                    print(f"    - レース番号: {possible_race}")
+    
+    def investigate_result_page(self, url):
+        """レース結果ページを詳細調査"""
+        print(f"\n### {url} の調査")
+        
+        try:
+            response = self.session.get(url, timeout=10)
+            print(f"ステータス: {response.status_code}")
+            
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.content, 'html.parser', from_encoding='shift_jis')
+                
+                # ページタイトル
+                title = soup.find('title')
+                if title:
+                    print(f"ページタイトル: {title.text.strip()}")
+                
+                # レース名を探す
+                race_name = None
+                h1_tags = soup.find_all('h1')
+                h2_tags = soup.find_all('h2')
+                h3_tags = soup.find_all('h3')
+                
+                for tag in h1_tags + h2_tags + h3_tags:
+                    text = tag.text.strip()
+                    if 'レース' in text or 'R' in text:
+                        race_name = text
+                        print(f"レース名: {race_name}")
+                        break
+                
+                # テーブルを探す
+                tables = soup.find_all('table')
+                print(f"\nテーブル数: {len(tables)}")
+                
+                for i, table in enumerate(tables):
+                    # テーブルのクラスやIDを確認
+                    table_class = table.get('class', [])
+                    table_id = table.get('id', '')
+                    
+                    print(f"\nテーブル{i+1}:")
+                    if table_class:
+                        print(f"  クラス: {table_class}")
+                    if table_id:
+                        print(f"  ID: {table_id}")
+                    
+                    # ヘッダーを確認
+                    headers = []
+                    th_tags = table.find_all('th')
+                    if th_tags:
+                        headers = [th.text.strip() for th in th_tags]
+                        print(f"  ヘッダー: {headers[:15]}")  # 最初の15個
+                        
+                        # レース結果テーブルの可能性を判定
+                        result_keywords = ['着順', '馬番', '馬名', 'タイム', '騎手', '調教師', 'オッズ', '人気']
+                        matches = [kw for kw in result_keywords if any(kw in h for h in headers)]
+                        if matches:
+                            print(f"  ✅ レース結果テーブルの可能性大！ マッチキーワード: {matches}")
+                            
+                            # 最初の数行のデータを確認
+                            rows = table.find_all('tr')[1:4]  # ヘッダー以外の最初の3行
+                            for j, row in enumerate(rows):
+                                cells = row.find_all(['td', 'th'])
+                                cell_texts = [cell.text.strip() for cell in cells[:10]]
+                                print(f"    データ行{j+1}: {cell_texts}")
+                    
+                    # 行数を確認
+                    rows = table.find_all('tr')
+                    print(f"  行数: {len(rows)}")
+                
+                # その他の重要な要素を探す
+                # レース条件
+                race_info_patterns = [
+                    r'ダート\d+m',
+                    r'\d+万下',
+                    r'[A-Z]\d+',
+                    r'サラ系\d+歳',
+                    r'牝馬限定',
+                    r'天候：[晴曇雨雪]+',
+                    r'馬場：[良稍重不]+',
+                ]
+                
+                page_text = soup.text
+                print("\n### レース条件の抽出:")
+                for pattern in race_info_patterns:
+                    matches = re.findall(pattern, page_text)
+                    if matches:
+                        print(f"  {pattern}: {matches[:3]}")  # 最初の3つ
+                
+                # リンクを確認（他のレースへのナビゲーション）
+                print("\n### ナビゲーションリンク:")
+                nav_links = []
+                for link in soup.find_all('a', href=True):
+                    href = link.get('href', '')
+                    text = link.text.strip()
+                    
+                    if 'result' in href and text and len(text) < 20:
+                        nav_links.append({
+                            'text': text,
+                            'href': urljoin(url, href)
+                        })
+                
+                # 重複を除去して表示
+                unique_links = []
+                seen = set()
+                for link in nav_links:
+                    if link['href'] not in seen:
+                        seen.add(link['href'])
+                        unique_links.append(link)
+                
+                for link in unique_links[:10]:
+                    print(f"  - {link['text']}: {link['href']}")
+                    
+            else:
+                print(f"❌ アクセス失敗")
+                
+        except Exception as e:
+            print(f"❌ エラー: {e}")
+    
+    def investigate_all_samples(self):
+        """すべてのサンプルURLを調査"""
+        print("\n" + "=" * 60)
+        print("レース結果ページの詳細調査")
+        print("=" * 60)
+        
+        for i, url in enumerate(self.sample_result_urls[:3]):  # 最初の3つを詳しく調査
+            if i > 0:
+                time.sleep(1)  # サーバーに配慮
+            self.investigate_result_page(url)
+    
+    def find_race_list_page(self):
+        """レース一覧ページを探す"""
+        print("\n" + "=" * 60)
+        print("レース一覧ページの探索")
+        print("=" * 60)
+        
+        # 可能性のあるURL
+        test_urls = [
+            "http://www.nankankeiba.com/program/00000000000000.do",  # 東京シティから発見
+            "http://www.nankankeiba.com/result/",
+            "http://www.nankankeiba.com/race_list.do",
+            "http://www.nankankeiba.com/schedule/",
+            "http://www.nankankeiba.com/calendar/",
+        ]
+        
+        for url in test_urls:
+            print(f"\n試行中: {url}")
+            try:
+                response = self.session.get(url, timeout=10)
+                print(f"ステータス: {response.status_code}")
+                
+                if response.status_code == 200:
+                    soup = BeautifulSoup(response.content, 'html.parser', from_encoding='shift_jis')
+                    
+                    # 大井競馬の情報を探す
+                    if '大井' in soup.text or 'TCK' in soup.text or '東京シティ' in soup.text:
+                        print("✅ 大井競馬関連の情報が含まれています！")
+                        
+                        # レースリンクを探す
+                        race_links = []
+                        for link in soup.find_all('a', href=True):
+                            href = link.get('href', '')
+                            text = link.text.strip()
+                            
+                            if ('result' in href or 'race' in href) and text:
+                                race_links.append({
+                                    'text': text[:50],  # 長すぎる場合は切る
+                                    'href': urljoin(url, href)
+                                })
+                        
+                        if race_links:
+                            print(f"レース関連リンク: {len(race_links)}個")
+                            for link in race_links[:5]:
+                                print(f"  - {link['text']}: {link['href']}")
+                                
+            except Exception as e:
+                print(f"❌ エラー: {type(e).__name__}")
+            
+            time.sleep(1)
+    
+    def generate_report(self):
+        """調査レポートを生成"""
+        print("\n" + "=" * 60)
+        print("調査結果レポート")
+        print("=" * 60)
+        
+        print("""
+### URLパターンの解析結果:
+- 形式: /result/YYYYMMDD[競馬場][開催][日次][レース].do
+- 例: /result/2025012920160311.do
+  - 20250129: 2025年1月29日
+  - 20: 大井競馬場のコード（推定）
+  - 16: 第16回開催
+  - 03: 3日目
+  - 11: 第11レース
+
+### データ取得戦略:
+1. 東京シティ競馬サイトから開催日とレース結果URLを取得
+2. 南関競馬サイトから実際のレース結果データを取得
+3. テーブル構造を解析してデータを抽出
+
+### 実装のポイント:
+- 文字エンコーディング: Shift-JIS
+- レース結果テーブルの識別: ヘッダーにキーワードを含む
+- URLパターンの理解: 日付とレース識別子の構造
+        """)
+
+def main():
+    print("南関競馬サイトの調査を開始します...")
+    print("=" * 60)
+    
+    investigator = NankanKeibaInvestigator()
+    
+    # 調査実行
+    investigator.check_robots_txt()
+    investigator.analyze_url_pattern()
+    investigator.investigate_all_samples()
+    investigator.find_race_list_page()
+    investigator.generate_report()
+    
+    print("\n調査完了！")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/investigate_tokyo_city.py
+++ b/scripts/investigate_tokyo_city.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+東京シティ競馬公式サイトの構造を調査するスクリプト
+"""
+import requests
+from bs4 import BeautifulSoup
+import time
+from datetime import datetime, timedelta
+import json
+from urllib.parse import urljoin
+
+class TokyoCityInvestigator:
+    def __init__(self):
+        self.base_url = "https://www.tokyocitykeiba.com/"
+        self.headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        }
+        self.session = requests.Session()
+        self.session.headers.update(self.headers)
+    
+    def check_robots_txt(self):
+        """robots.txtを確認"""
+        print("=" * 60)
+        print("robots.txtの確認")
+        print("=" * 60)
+        
+        try:
+            url = urljoin(self.base_url, "robots.txt")
+            response = self.session.get(url)
+            
+            if response.status_code == 200:
+                print("✅ robots.txt が見つかりました:")
+                print(response.text)
+            else:
+                print(f"❌ robots.txt が見つかりません (ステータス: {response.status_code})")
+        except Exception as e:
+            print(f"❌ エラー: {e}")
+    
+    def investigate_homepage(self):
+        """トップページの構造を調査"""
+        print("\n" + "=" * 60)
+        print("トップページの調査")
+        print("=" * 60)
+        
+        try:
+            response = self.session.get(self.base_url)
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            print(f"ステータスコード: {response.status_code}")
+            print(f"ページタイトル: {soup.title.text if soup.title else 'なし'}")
+            
+            # ナビゲーションメニューを探す
+            print("\n### ナビゲーションリンク:")
+            nav_links = soup.find_all('a', href=True)[:20]  # 最初の20個
+            for link in nav_links:
+                href = link.get('href', '')
+                text = link.text.strip()
+                if text and ('レース' in text or '結果' in text or '出走' in text or 'データ' in text):
+                    print(f"- {text}: {urljoin(self.base_url, href)}")
+            
+            # 開催情報を探す
+            print("\n### 開催情報の要素:")
+            for tag in ['div', 'section', 'article']:
+                elements = soup.find_all(tag, class_=lambda x: x and ('race' in x.lower() or 'schedule' in x.lower() or 'kaisai' in x.lower()) if x else False)
+                for elem in elements[:5]:
+                    print(f"- {tag}.{elem.get('class', [''])[0]}: {elem.text.strip()[:50]}...")
+            
+        except Exception as e:
+            print(f"❌ エラー: {e}")
+    
+    def find_race_pages(self):
+        """レース関連ページを探す"""
+        print("\n" + "=" * 60)
+        print("レース関連ページの探索")
+        print("=" * 60)
+        
+        # 一般的なレース関連URLパターン
+        patterns = [
+            "race/",
+            "result/",
+            "results/",
+            "data/",
+            "past/",
+            "schedule/",
+            "calendar/",
+            "racelist/",
+            "racedata/",
+            "program/",
+            "shutuba/",
+            "odds/"
+        ]
+        
+        found_urls = set()
+        
+        try:
+            response = self.session.get(self.base_url)
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            # すべてのリンクを確認
+            for link in soup.find_all('a', href=True):
+                href = link.get('href', '')
+                full_url = urljoin(self.base_url, href)
+                
+                # パターンマッチング
+                for pattern in patterns:
+                    if pattern in href.lower():
+                        found_urls.add((link.text.strip(), full_url))
+                        break
+            
+            # 結果を表示
+            if found_urls:
+                print("✅ レース関連と思われるページが見つかりました:")
+                for text, url in sorted(found_urls):
+                    if text:
+                        print(f"- {text}: {url}")
+            else:
+                print("❌ レース関連ページが見つかりませんでした")
+                
+        except Exception as e:
+            print(f"❌ エラー: {e}")
+    
+    def test_specific_urls(self):
+        """特定のURLパターンをテスト"""
+        print("\n" + "=" * 60)
+        print("特定URLパターンのテスト")
+        print("=" * 60)
+        
+        # テストするURL
+        test_urls = [
+            "race/result/",
+            "race/2025/06/",
+            "data/race/",
+            "schedule/",
+            "program/",
+            "past/",
+            "results/2025/06/",
+            "race/past/",
+            "race/schedule/"
+        ]
+        
+        for path in test_urls:
+            url = urljoin(self.base_url, path)
+            print(f"\n試行中: {url}")
+            
+            try:
+                response = self.session.get(url, timeout=10)
+                print(f"ステータス: {response.status_code}")
+                
+                if response.status_code == 200:
+                    soup = BeautifulSoup(response.content, 'html.parser')
+                    
+                    # ページ内容を確認
+                    if 'レース' in soup.text or 'race' in soup.text.lower():
+                        print("✅ レース関連コンテンツが含まれています")
+                        
+                        # テーブルを探す
+                        tables = soup.find_all('table')
+                        if tables:
+                            print(f"  - テーブル数: {len(tables)}")
+                            
+                        # レース結果のようなデータを探す
+                        race_elements = soup.find_all(['div', 'tr', 'section'], 
+                                                    class_=lambda x: x and ('race' in str(x).lower() or 'result' in str(x).lower()) if x else False)
+                        if race_elements:
+                            print(f"  - レース関連要素: {len(race_elements)}個")
+                    else:
+                        print("❌ レース関連コンテンツが見つかりません")
+                        
+            except requests.exceptions.RequestException as e:
+                print(f"❌ アクセスエラー: {type(e).__name__}")
+            
+            time.sleep(1)  # サーバーに負荷をかけない
+    
+    def investigate_date_based_urls(self):
+        """日付ベースのURLを調査"""
+        print("\n" + "=" * 60)
+        print("日付ベースURLの調査")
+        print("=" * 60)
+        
+        # 最近の日付でテスト
+        test_date = datetime(2025, 6, 25)
+        
+        # 様々な日付フォーマット
+        date_formats = [
+            test_date.strftime("%Y%m%d"),      # 20250625
+            test_date.strftime("%Y/%m/%d"),    # 2025/06/25
+            test_date.strftime("%Y-%m-%d"),    # 2025-06-25
+            test_date.strftime("%Y/%m%d"),     # 2025/0625
+            test_date.strftime("%Y%m/%d"),     # 202506/25
+        ]
+        
+        base_paths = ["race/", "result/", "data/", "schedule/", "program/"]
+        
+        for base_path in base_paths:
+            for date_format in date_formats:
+                url = urljoin(self.base_url, f"{base_path}{date_format}")
+                print(f"\n試行中: {url}")
+                
+                try:
+                    response = self.session.get(url, timeout=10)
+                    if response.status_code == 200:
+                        print(f"✅ アクセス成功!")
+                        soup = BeautifulSoup(response.content, 'html.parser')
+                        
+                        # レース情報を探す
+                        if 'レース' in soup.text or '大井' in soup.text:
+                            print("  - レース情報が含まれています！")
+                            
+                            # より詳細な調査
+                            self.analyze_page_structure(soup, url)
+                            return url  # 成功したURLを返す
+                    else:
+                        print(f"❌ ステータス: {response.status_code}")
+                        
+                except Exception as e:
+                    print(f"❌ エラー: {type(e).__name__}")
+                
+                time.sleep(1)
+    
+    def analyze_page_structure(self, soup, url):
+        """ページの詳細構造を分析"""
+        print("\n### ページ構造の詳細分析:")
+        
+        # レース一覧を探す
+        race_links = []
+        for link in soup.find_all('a', href=True):
+            href = link.get('href', '')
+            text = link.text.strip()
+            
+            if ('R' in text and text[0:2].isdigit()) or ('レース' in text):
+                race_links.append({
+                    'text': text,
+                    'href': urljoin(url, href)
+                })
+        
+        if race_links:
+            print(f"✅ {len(race_links)}個のレースリンクを発見:")
+            for i, link in enumerate(race_links[:5]):  # 最初の5つを表示
+                print(f"  {i+1}. {link['text']}: {link['href']}")
+        
+        # テーブル構造を確認
+        tables = soup.find_all('table')
+        if tables:
+            print(f"\n✅ {len(tables)}個のテーブルを発見")
+            for i, table in enumerate(tables[:2]):  # 最初の2つを分析
+                print(f"\n  テーブル{i+1}:")
+                
+                # ヘッダーを確認
+                headers = table.find_all('th')
+                if headers:
+                    print(f"  ヘッダー: {[h.text.strip() for h in headers[:5]]}")
+                
+                # 行数を確認
+                rows = table.find_all('tr')
+                print(f"  行数: {len(rows)}")
+    
+    def search_api_endpoints(self):
+        """APIエンドポイントを探す"""
+        print("\n" + "=" * 60)
+        print("APIエンドポイントの探索")
+        print("=" * 60)
+        
+        try:
+            response = self.session.get(self.base_url)
+            content = response.text
+            
+            # JavaScriptファイルを探す
+            import re
+            js_files = re.findall(r'<script[^>]+src=["\']([^"\']+\.js)["\']', content)
+            
+            print(f"JavaScriptファイル数: {len(js_files)}")
+            
+            # APIパターンを探す
+            api_patterns = [
+                r'api/',
+                r'/ajax/',
+                r'\.json',
+                r'data/',
+                r'fetch\(["\']([^"\']+)["\']',
+                r'axios\.[get|post]\(["\']([^"\']+)["\']'
+            ]
+            
+            for pattern in api_patterns:
+                matches = re.findall(pattern, content, re.IGNORECASE)
+                if matches:
+                    print(f"\n✅ パターン '{pattern}' にマッチ:")
+                    for match in matches[:3]:
+                        print(f"  - {match}")
+                        
+        except Exception as e:
+            print(f"❌ エラー: {e}")
+    
+    def generate_report(self):
+        """調査結果のレポートを生成"""
+        print("\n" + "=" * 60)
+        print("調査結果サマリー")
+        print("=" * 60)
+        
+        print("""
+### 推奨される次のステップ:
+1. 見つかったレース関連URLを詳細に調査
+2. レース結果ページの具体的な構造を分析
+3. データ抽出のためのセレクターを特定
+4. プロトタイプスクレイパーの作成
+
+### 注意事項:
+- robots.txtの内容を確認し、遵守する
+- アクセス間隔は1秒以上空ける
+- User-Agentを適切に設定する
+        """)
+
+def main():
+    print("東京シティ競馬サイトの調査を開始します...")
+    print("=" * 60)
+    
+    investigator = TokyoCityInvestigator()
+    
+    # 調査実行
+    investigator.check_robots_txt()
+    investigator.investigate_homepage()
+    investigator.find_race_pages()
+    investigator.test_specific_urls()
+    investigator.investigate_date_based_urls()
+    investigator.search_api_endpoints()
+    investigator.generate_report()
+    
+    print("\n調査完了！")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/investigate_tokyo_city_deep.py
+++ b/scripts/investigate_tokyo_city_deep.py
@@ -1,0 +1,358 @@
+#!/usr/bin/env python3
+"""
+東京シティ競馬サイトの詳細調査スクリプト
+見つかったURLを深く調査し、レース結果へのアクセス方法を探る
+"""
+import requests
+from bs4 import BeautifulSoup
+import time
+from datetime import datetime, timedelta
+import json
+from urllib.parse import urljoin, urlparse
+import re
+
+class TokyoCityDeepInvestigator:
+    def __init__(self):
+        self.base_url = "https://www.tokyocitykeiba.com/"
+        self.headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        }
+        self.session = requests.Session()
+        self.session.headers.update(self.headers)
+        
+        # 調査対象URL
+        self.target_urls = {
+            'calendar': 'https://www.tokyocitykeiba.com/race/calendar/',
+            'schedule': 'https://www.tokyocitykeiba.com/race/schedule/',
+            'race_main': 'https://www.tokyocitykeiba.com/race/',
+            'grade_race': 'https://www.tokyocitykeiba.com/race/grade_race/'
+        }
+    
+    def investigate_calendar(self):
+        """開催カレンダーページを詳細調査"""
+        print("=" * 60)
+        print("開催カレンダーの詳細調査")
+        print("=" * 60)
+        
+        try:
+            response = self.session.get(self.target_urls['calendar'])
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            print(f"ステータス: {response.status_code}")
+            
+            # カレンダー要素を探す
+            calendar_elements = soup.find_all(['div', 'table', 'section'], 
+                                            class_=lambda x: x and ('calendar' in str(x).lower() or 'schedule' in str(x).lower()) if x else False)
+            
+            print(f"\nカレンダー関連要素: {len(calendar_elements)}個")
+            
+            # 日付リンクを探す
+            date_links = []
+            for link in soup.find_all('a', href=True):
+                text = link.text.strip()
+                href = link.get('href', '')
+                
+                # 日付パターンを探す
+                if re.search(r'\d{1,2}[月/]\d{1,2}', text) or re.search(r'開催', text):
+                    date_links.append({
+                        'text': text,
+                        'href': urljoin(self.target_urls['calendar'], href)
+                    })
+            
+            if date_links:
+                print(f"\n✅ {len(date_links)}個の日付関連リンクを発見:")
+                for i, link in enumerate(date_links[:10]):  # 最初の10個
+                    print(f"{i+1}. {link['text']}: {link['href']}")
+                    
+                # 最初のリンクを詳細調査
+                if date_links:
+                    print(f"\n### 最初のリンクを調査: {date_links[0]['href']}")
+                    self.follow_link(date_links[0]['href'])
+            
+            # スクリプトタグ内のデータを探す
+            scripts = soup.find_all('script')
+            for script in scripts:
+                if script.string and ('calendar' in script.string.lower() or 'schedule' in script.string.lower()):
+                    print("\n✅ カレンダー関連のJavaScriptデータを発見")
+                    # JSON形式のデータを探す
+                    json_matches = re.findall(r'\{[^}]+\}', script.string)
+                    if json_matches:
+                        print(f"  JSONオブジェクト数: {len(json_matches)}")
+                        
+        except Exception as e:
+            print(f"❌ エラー: {e}")
+    
+    def investigate_race_main(self):
+        """レースメインページを調査"""
+        print("\n" + "=" * 60)
+        print("レースメインページの詳細調査")
+        print("=" * 60)
+        
+        try:
+            response = self.session.get(self.target_urls['race_main'])
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            print(f"ステータス: {response.status_code}")
+            
+            # レース関連のリンクを全て収集
+            race_links = []
+            for link in soup.find_all('a', href=True):
+                href = link.get('href', '')
+                text = link.text.strip()
+                
+                # レース関連のキーワード
+                if any(keyword in text for keyword in ['レース', '出走表', '結果', '成績', 'オッズ']):
+                    full_url = urljoin(self.target_urls['race_main'], href)
+                    race_links.append({
+                        'text': text,
+                        'href': full_url
+                    })
+            
+            if race_links:
+                print(f"\n✅ {len(race_links)}個のレース関連リンクを発見:")
+                # 重複を除去
+                unique_links = []
+                seen_urls = set()
+                for link in race_links:
+                    if link['href'] not in seen_urls:
+                        seen_urls.add(link['href'])
+                        unique_links.append(link)
+                
+                for i, link in enumerate(unique_links[:15]):
+                    print(f"{i+1}. {link['text']}: {link['href']}")
+            
+            # フォーム要素を探す（検索機能など）
+            forms = soup.find_all('form')
+            if forms:
+                print(f"\n✅ {len(forms)}個のフォームを発見")
+                for i, form in enumerate(forms):
+                    action = form.get('action', '')
+                    method = form.get('method', 'get')
+                    print(f"  フォーム{i+1}: action={action}, method={method}")
+                    
+                    # input要素を確認
+                    inputs = form.find_all('input')
+                    if inputs:
+                        print(f"    入力フィールド:")
+                        for inp in inputs[:5]:
+                            print(f"      - {inp.get('name', 'no-name')}: {inp.get('type', 'text')}")
+                            
+        except Exception as e:
+            print(f"❌ エラー: {e}")
+    
+    def investigate_nankan_keiba(self):
+        """南関競馬サイトを調査"""
+        print("\n" + "=" * 60)
+        print("南関競馬サイトの調査")
+        print("=" * 60)
+        
+        nankan_url = "http://www.nankankeiba.com/program/00000000000000.do"
+        
+        try:
+            response = self.session.get(nankan_url, timeout=10)
+            print(f"ステータス: {response.status_code}")
+            
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.content, 'html.parser')
+                
+                # 大井競馬関連の情報を探す
+                if '大井' in soup.text:
+                    print("✅ 大井競馬の情報が含まれています")
+                    
+                    # プログラムやレース結果のリンクを探す
+                    links = soup.find_all('a', href=True)
+                    oi_links = []
+                    
+                    for link in links:
+                        text = link.text.strip()
+                        href = link.get('href', '')
+                        
+                        if '大井' in text or 'TCK' in text:
+                            oi_links.append({
+                                'text': text,
+                                'href': urljoin(nankan_url, href)
+                            })
+                    
+                    if oi_links:
+                        print(f"\n大井競馬関連リンク: {len(oi_links)}個")
+                        for i, link in enumerate(oi_links[:10]):
+                            print(f"{i+1}. {link['text']}: {link['href']}")
+                            
+        except Exception as e:
+            print(f"❌ エラー: {e}")
+    
+    def follow_link(self, url):
+        """リンクを追跡して詳細を調査"""
+        try:
+            time.sleep(1)  # 礼儀正しく待機
+            response = self.session.get(url, timeout=10)
+            
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.content, 'html.parser')
+                
+                # レース結果テーブルを探す
+                tables = soup.find_all('table')
+                if tables:
+                    print(f"  → テーブル数: {len(tables)}")
+                    
+                    for i, table in enumerate(tables[:2]):
+                        # ヘッダーを確認
+                        headers = table.find_all('th')
+                        if headers:
+                            header_texts = [h.text.strip() for h in headers[:8]]
+                            print(f"    テーブル{i+1}のヘッダー: {header_texts}")
+                            
+                            # レース結果っぽいキーワードを探す
+                            result_keywords = ['着順', '馬番', '馬名', 'タイム', 'オッズ', '騎手', '調教師']
+                            if any(keyword in str(header_texts) for keyword in result_keywords):
+                                print(f"    ✅ レース結果テーブルの可能性が高い！")
+                
+                # レース詳細リンクを探す
+                race_detail_links = []
+                for link in soup.find_all('a', href=True):
+                    text = link.text.strip()
+                    if re.match(r'\d+R', text) or 'レース' in text:
+                        race_detail_links.append({
+                            'text': text,
+                            'href': urljoin(url, link.get('href'))
+                        })
+                
+                if race_detail_links:
+                    print(f"  → レース詳細リンク: {len(race_detail_links)}個")
+                    for link in race_detail_links[:3]:
+                        print(f"    - {link['text']}: {link['href']}")
+                        
+            else:
+                print(f"  → アクセス失敗: {response.status_code}")
+                
+        except Exception as e:
+            print(f"  → エラー: {type(e).__name__}")
+    
+    def check_ajax_endpoints(self):
+        """Ajax APIエンドポイントを調査"""
+        print("\n" + "=" * 60)
+        print("Ajax APIエンドポイントの調査")
+        print("=" * 60)
+        
+        # 可能性のあるAjaxエンドポイント
+        ajax_endpoints = [
+            '/ajax/race',
+            '/ajax/result',
+            '/ajax/schedule',
+            '/ajax/calendar',
+            '/ajax/program',
+            '/wp-admin/admin-ajax.php'  # WordPressの標準Ajax
+        ]
+        
+        for endpoint in ajax_endpoints:
+            url = urljoin(self.base_url, endpoint)
+            print(f"\n試行中: {url}")
+            
+            try:
+                # GETリクエスト
+                response = self.session.get(url, timeout=5)
+                print(f"  GET: {response.status_code}")
+                
+                # POSTリクエスト（WordPressのajaxはPOSTが一般的）
+                if 'admin-ajax.php' in endpoint:
+                    # 一般的なWordPress Ajaxアクション
+                    test_actions = ['get_race_data', 'load_race_results', 'fetch_schedule']
+                    
+                    for action in test_actions:
+                        data = {'action': action}
+                        response = self.session.post(url, data=data, timeout=5)
+                        print(f"  POST (action={action}): {response.status_code}")
+                        
+                        if response.status_code == 200 and response.text.strip() != '0':
+                            print(f"    ✅ 有効なレスポンス: {response.text[:100]}...")
+                            
+            except Exception as e:
+                print(f"  ❌ エラー: {type(e).__name__}")
+            
+            time.sleep(0.5)
+    
+    def investigate_schedule_detail(self):
+        """スケジュールページの詳細調査"""
+        print("\n" + "=" * 60)
+        print("スケジュールページの詳細調査")
+        print("=" * 60)
+        
+        try:
+            response = self.session.get(self.target_urls['schedule'])
+            soup = BeautifulSoup(response.content, 'html.parser')
+            
+            # テーブル構造を詳しく分析
+            tables = soup.find_all('table')
+            for i, table in enumerate(tables):
+                print(f"\nテーブル{i+1}の分析:")
+                
+                # キャプションを確認
+                caption = table.find('caption')
+                if caption:
+                    print(f"  キャプション: {caption.text.strip()}")
+                
+                # 行を分析
+                rows = table.find_all('tr')
+                print(f"  行数: {len(rows)}")
+                
+                if rows:
+                    # 最初の数行を詳細に分析
+                    for j, row in enumerate(rows[:5]):
+                        cells = row.find_all(['td', 'th'])
+                        cell_texts = [cell.text.strip() for cell in cells]
+                        print(f"    行{j+1}: {cell_texts}")
+                        
+                        # リンクを確認
+                        links = row.find_all('a', href=True)
+                        if links:
+                            for link in links:
+                                print(f"      → リンク: {link.text.strip()} => {link.get('href')}")
+                                
+        except Exception as e:
+            print(f"❌ エラー: {e}")
+    
+    def generate_findings(self):
+        """調査結果をまとめる"""
+        print("\n" + "=" * 60)
+        print("調査結果のまとめ")
+        print("=" * 60)
+        
+        print("""
+### 主な発見:
+1. 東京シティ競馬サイトはWordPressベース
+2. レース情報は以下の構造：
+   - /race/calendar/ - 開催カレンダー
+   - /race/schedule/ - 詳細スケジュール
+   - 個別のレース結果は別システムの可能性
+3. 南関競馬サイトとの連携がある
+
+### データ取得戦略:
+1. まず開催カレンダーから開催日を取得
+2. 各開催日のレース情報へアクセス
+3. 南関競馬サイトも併用する可能性
+4. WordPress AjaxAPIの活用を検討
+
+### 次のアクション:
+1. 実際の開催日でのアクセステスト
+2. 南関競馬サイトの詳細調査
+3. プロトタイプスクレイパーの作成
+        """)
+
+def main():
+    print("東京シティ競馬サイトの詳細調査を開始します...")
+    print("=" * 60)
+    
+    investigator = TokyoCityDeepInvestigator()
+    
+    # 詳細調査実行
+    investigator.investigate_calendar()
+    investigator.investigate_race_main()
+    investigator.investigate_schedule_detail()
+    investigator.investigate_nankan_keiba()
+    investigator.check_ajax_endpoints()
+    investigator.generate_findings()
+    
+    print("\n詳細調査完了！")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_tokyo_city_scraper.py
+++ b/scripts/test_tokyo_city_scraper.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""
+東京シティ競馬（大井競馬）スクレイパーのプロトタイプ
+東京シティ競馬サイトと南関競馬サイトを組み合わせてデータを取得
+"""
+import sys
+import os
+sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import requests
+from bs4 import BeautifulSoup
+import time
+from datetime import datetime, timedelta
+import re
+from urllib.parse import urljoin
+import pandas as pd
+from typing import List, Dict, Optional
+
+from src.utils.logger import setup_logger
+
+logger = setup_logger(__name__)
+
+class TokyoCityScraper:
+    def __init__(self):
+        self.tokyo_city_base = "https://www.tokyocitykeiba.com/"
+        self.nankan_base = "http://www.nankankeiba.com/"
+        
+        self.headers = {
+            'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36'
+        }
+        self.session = requests.Session()
+        self.session.headers.update(self.headers)
+        
+        # 大井競馬場のコード
+        self.OI_TRACK_CODE = "20"
+    
+    def get_race_schedule(self, start_date: datetime, end_date: datetime) -> List[Dict]:
+        """
+        東京シティ競馬サイトから開催スケジュールを取得
+        """
+        logger.info(f"開催スケジュールを取得: {start_date.strftime('%Y-%m-%d')} 〜 {end_date.strftime('%Y-%m-%d')}")
+        
+        schedules = []
+        
+        try:
+            # レースメインページから情報を取得
+            url = urljoin(self.tokyo_city_base, "race/")
+            response = self.session.get(url)
+            
+            if response.status_code == 200:
+                soup = BeautifulSoup(response.content, 'html.parser')
+                
+                # レース結果リンクを探す（南関競馬サイトへのリンク）
+                result_links = []
+                for link in soup.find_all('a', href=True):
+                    href = link.get('href', '')
+                    if 'nankankeiba.com/result/' in href:
+                        result_links.append(href)
+                
+                logger.info(f"見つかったレース結果リンク: {len(result_links)}個")
+                
+                # 各リンクから日付とレース情報を抽出
+                for link in result_links:
+                    match = re.search(r'/result/(\d{8})(\d+)\.do', link)
+                    if match:
+                        date_str = match.group(1)
+                        code_str = match.group(2)
+                        
+                        # 日付を解析
+                        race_date = datetime.strptime(date_str, '%Y%m%d')
+                        
+                        # 期間内のレースのみ
+                        if start_date <= race_date <= end_date:
+                            # コード部分を解析
+                            if len(code_str) >= 8 and code_str[:2] == self.OI_TRACK_CODE:
+                                kaisai = code_str[2:4]
+                                day = code_str[4:6]
+                                race_num = code_str[6:8]
+                                
+                                schedule = {
+                                    'date': race_date,
+                                    'kaisai': int(kaisai),
+                                    'day': int(day),
+                                    'race_num': int(race_num),
+                                    'url': link
+                                }
+                                schedules.append(schedule)
+                
+                # カレンダーページも確認
+                calendar_url = urljoin(self.tokyo_city_base, "race/calendar/")
+                response = self.session.get(calendar_url)
+                
+                if response.status_code == 200:
+                    soup = BeautifulSoup(response.content, 'html.parser')
+                    # 追加の開催情報があれば取得
+                    # （実装は実際のHTML構造に応じて調整）
+                    
+            else:
+                logger.error(f"スケジュール取得失敗: {response.status_code}")
+                
+        except Exception as e:
+            logger.error(f"スケジュール取得エラー: {e}")
+        
+        # 日付順にソート
+        schedules.sort(key=lambda x: (x['date'], x['race_num']))
+        
+        return schedules
+    
+    def scrape_race_result(self, result_url: str) -> Optional[List[Dict]]:
+        """
+        南関競馬サイトからレース結果を取得
+        """
+        logger.info(f"レース結果を取得: {result_url}")
+        
+        try:
+            response = self.session.get(result_url)
+            
+            if response.status_code == 200:
+                # Shift-JISでデコード
+                soup = BeautifulSoup(response.content, 'html.parser', from_encoding='shift_jis')
+                
+                # レース情報を取得
+                race_info = self._extract_race_info(soup, result_url)
+                
+                # 結果テーブルを探す
+                result_table = None
+                tables = soup.find_all('table', class_='nk23_c-table01__table')
+                
+                for table in tables:
+                    headers = [th.text.strip() for th in table.find_all('th')]
+                    # メインの結果テーブルを識別
+                    if '着' in headers and '馬名' in headers and 'タイム' in headers:
+                        result_table = table
+                        break
+                
+                if result_table:
+                    results = self._parse_result_table(result_table, race_info)
+                    logger.info(f"取得した結果: {len(results)}件")
+                    return results
+                else:
+                    logger.warning("結果テーブルが見つかりません")
+                    
+            else:
+                logger.error(f"アクセス失敗: {response.status_code}")
+                
+        except Exception as e:
+            logger.error(f"スクレイピングエラー: {e}")
+            
+        return None
+    
+    def _extract_race_info(self, soup: BeautifulSoup, url: str) -> Dict:
+        """
+        レース基本情報を抽出
+        """
+        # URLから日付とレース番号を抽出
+        match = re.search(r'/result/(\d{8})(\d{2})(\d{2})(\d{2})(\d{2})\.do', url)
+        
+        race_info = {
+            'race_date': '',
+            'kaisai': '',
+            'day': '',
+            'race_num': '',
+            'race_name': '',
+            'course_length': '',
+            'course_type': 'ダート',  # 大井は基本ダート
+            'weather': '',
+            'track_condition': ''
+        }
+        
+        if match:
+            date_str = match.group(1)
+            race_info['race_date'] = datetime.strptime(date_str, '%Y%m%d').strftime('%Y-%m-%d')
+            race_info['kaisai'] = f"第{int(match.group(2))}回"
+            race_info['day'] = f"{int(match.group(3))}日目"
+            race_info['race_num'] = f"{int(match.group(4))}R"
+        
+        # ページからレース名を取得
+        # （実際のHTML構造に応じて調整が必要）
+        h1_tags = soup.find_all('h1')
+        h2_tags = soup.find_all('h2')
+        
+        for tag in h1_tags + h2_tags:
+            text = tag.text.strip()
+            if 'レース' in text or 'R' in text:
+                race_info['race_name'] = text
+                break
+        
+        # コース情報を取得
+        for link in soup.find_all('a', href=True):
+            text = link.text.strip()
+            match = re.match(r'ダ(\d+)m', text)
+            if match:
+                race_info['course_length'] = match.group(1)
+                break
+        
+        return race_info
+    
+    def _parse_result_table(self, table, race_info: Dict) -> List[Dict]:
+        """
+        結果テーブルをパース
+        """
+        results = []
+        
+        # ヘッダーを取得
+        headers = []
+        header_row = table.find('tr')
+        if header_row:
+            headers = [th.text.strip() for th in header_row.find_all('th')]
+        
+        # データ行を処理
+        rows = table.find_all('tr')[1:]  # ヘッダーをスキップ
+        
+        for row in rows:
+            cells = row.find_all(['td', 'th'])
+            if len(cells) >= 10:  # 最低限必要なカラム数
+                
+                # インデックスマッピング（実際のテーブル構造に応じて調整）
+                try:
+                    result = {
+                        'race_id': f"{race_info['race_date'].replace('-', '')}{race_info['race_num'].replace('R', '')}",
+                        'race_date': race_info['race_date'],
+                        'race_name': race_info['race_name'],
+                        'race_num': race_info['race_num'],
+                        'kaisai': race_info['kaisai'],
+                        'day': race_info['day'],
+                        'course_length': race_info['course_length'],
+                        'course_type': race_info['course_type'],
+                        'weather': race_info['weather'],
+                        'track_condition': race_info['track_condition'],
+                        
+                        # レース結果データ
+                        'finish_position': cells[0].text.strip(),
+                        'frame_number': cells[1].text.strip(),
+                        'horse_number': cells[2].text.strip(),
+                        'horse_name': cells[3].text.strip().replace('[J]', ''),  # JRA転入馬マーク除去
+                        'sex_age': cells[4].text.strip(),
+                        'weight_carried': cells[5].text.strip().replace('kg', ''),
+                        'horse_weight': cells[6].text.strip().replace('kg', ''),
+                        'weight_change': cells[7].text.strip(),
+                        'jockey_name': cells[8].text.strip().replace('[J]', ''),
+                        'trainer_name': cells[9].text.strip(),
+                        'time': cells[10].text.strip() if len(cells) > 10 else '',
+                        'margin': cells[11].text.strip() if len(cells) > 11 else '',
+                        'last_3f': cells[12].text.strip() if len(cells) > 12 else '',
+                        'corner_position': cells[13].text.strip() if len(cells) > 13 else '',
+                        'popularity': cells[14].text.strip() if len(cells) > 14 else '',
+                        
+                        # オッズは別テーブルから取得する必要があるかも
+                        'odds': '',
+                        'prize_money': ''
+                    }
+                    
+                    # 数値データの整形
+                    if result['finish_position'].isdigit():
+                        results.append(result)
+                        
+                except Exception as e:
+                    logger.warning(f"行のパースエラー: {e}")
+                    continue
+        
+        return results
+    
+    def test_single_race(self):
+        """
+        単一レースでテスト
+        """
+        test_url = "http://www.nankankeiba.com/result/2025012920160311.do"
+        logger.info(f"テストURL: {test_url}")
+        
+        results = self.scrape_race_result(test_url)
+        
+        if results:
+            logger.info(f"成功！ {len(results)}件の結果を取得")
+            
+            # 最初の3件を表示
+            for i, result in enumerate(results[:3]):
+                logger.info(f"\n{i+1}着:")
+                logger.info(f"  馬名: {result['horse_name']}")
+                logger.info(f"  騎手: {result['jockey_name']}")
+                logger.info(f"  タイム: {result['time']}")
+                logger.info(f"  人気: {result['popularity']}")
+            
+            # DataFrameとして表示
+            df = pd.DataFrame(results)
+            print("\n結果のDataFrame:")
+            print(df[['finish_position', 'horse_name', 'jockey_name', 'time', 'popularity']].head())
+            
+            return True
+        else:
+            logger.error("テスト失敗")
+            return False
+    
+    def run_date_range(self, start_date: datetime, end_date: datetime):
+        """
+        指定期間のレースデータを取得
+        """
+        # スケジュールを取得
+        schedules = self.get_race_schedule(start_date, end_date)
+        logger.info(f"取得対象レース: {len(schedules)}件")
+        
+        all_results = []
+        
+        for schedule in schedules[:5]:  # テストとして最初の5レースのみ
+            logger.info(f"\n処理中: {schedule['date'].strftime('%Y-%m-%d')} {schedule['race_num']}R")
+            
+            results = self.scrape_race_result(schedule['url'])
+            if results:
+                all_results.extend(results)
+            
+            # サーバーに配慮
+            time.sleep(1)
+        
+        logger.info(f"\n合計取得結果: {len(all_results)}件")
+        return all_results
+
+def main():
+    """メイン処理"""
+    logger.info("東京シティ競馬スクレイパーのテスト開始")
+    
+    scraper = TokyoCityScraper()
+    
+    # 単一レースのテスト
+    logger.info("\n=== 単一レーステスト ===")
+    if scraper.test_single_race():
+        logger.info("✅ 単一レーステスト成功！")
+        
+        # 期間指定のテスト
+        logger.info("\n=== 期間指定テスト ===")
+        start_date = datetime(2025, 1, 1)
+        end_date = datetime(2025, 1, 31)
+        
+        results = scraper.run_date_range(start_date, end_date)
+        
+        if results:
+            logger.info("✅ 期間指定テスト成功！")
+            
+            # CSVに保存
+            df = pd.DataFrame(results)
+            df.to_csv('test_results.csv', index=False, encoding='utf-8-sig')
+            logger.info("結果をtest_results.csvに保存しました")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 📋 概要
東京シティ競馬サイトと南関競馬サイトの調査を完了し、プロトタイプスクレイパーを実装しました。

## 🔍 調査結果

### 東京シティ競馬サイト
- WordPressベースのサイト
- レース結果は南関競馬サイトへのリンク
- robots.txtは寛容（wp-admin以外OK）

### 南関競馬サイト
- URLパターン: `/result/YYYYMMDD20KKDDLL.do`
  - 20: 大井競馬場コード
  - KK: 開催回次
  - DD: 日次
  - LL: レース番号
- 文字エンコーディング: Shift-JIS
- テーブルクラス: `nk23_c-table01__table`

## 📝 実装内容

### 調査スクリプト
1. `scripts/investigate_tokyo_city.py` - 初期調査
2. `scripts/investigate_tokyo_city_deep.py` - 詳細調査
3. `scripts/investigate_nankan_keiba.py` - 南関競馬調査

### プロトタイプ
- `scripts/test_tokyo_city_scraper.py`
  - 2段階データ取得（東京シティ→南関）
  - レース結果のパース機能
  - テスト機能付き

## 🧪 テスト方法
```bash
# 単一レースのテスト
python3 scripts/test_tokyo_city_scraper.py
```

## ✅ 関連Issue
- Closes #8 - netkeibaスクレイピング問題の調査完了
- Addresses #9 - 東京シティ競馬スクレイパーの基礎実装

## 📋 今後の作業
- [ ] プロトタイプの本番環境テスト
- [ ] `src/data_collection/tokyo_city_scraper.py`として本実装
- [ ] 既存システムとの統合
- [ ] データベーススキーマの最適化